### PR TITLE
Fix typo where `;` is wrongly inside `""` in `Field.null` documentation

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -46,7 +46,7 @@ Avoid using :attr:`~Field.null` on string-based fields such as
 :class:`CharField` and :class:`TextField`. If a string-based field has
 ``null=True``, that means it has two possible values for "no data": ``NULL``,
 and the empty string. In most cases, it's redundant to have two possible values
-for "no data;" the Django convention is to use the empty string, not
+for "no data"; the Django convention is to use the empty string, not
 ``NULL``. One exception is when a :class:`CharField` has both ``unique=True``
 and ``blank=True`` set. In this situation, ``null=True`` is required to avoid
 unique constraint violations when saving multiple objects with blank values.


### PR DESCRIPTION
[Live docs link](https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.Field.null)

I'm going to assume I haven't missed some special significance to `"no data;"`.